### PR TITLE
Performance improvement for toJsAny

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,9 @@ Further, `toFloat` on `JNumber` (see [Number Conversions](#number-conversions) )
 strict-floats enabled in your application. Please see the [Scala.js semantics page](https://www.scala-js.org/doc/semantics.html)
 for more information.
 
+Since `scalajson.ast.unsafe.JArray` uses `js.Array` underneath this gives us performance improvements for certain
+methods, i.e. the `scalajson.ast.unsafe.JArray.toJsAny` mutates an array in place to provide better performance. 
+
 ## jNumberRegex
 `scalajson.JNumber` uses `jNumberRegex` to validate whether a number is a valid
 JSON number. One can use `jNumberRegex` explicitly if you want to use the validation that

--- a/js/src/main/scala-2.10/scalajson.ast/unsafe/JValue.scala
+++ b/js/src/main/scala-2.10/scalajson.ast/unsafe/JValue.scala
@@ -5,6 +5,7 @@ import scalajson.ast
 import scalajson.ast._
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSExport
+import scala.scalajs.js.|
 
 /** Represents a JSON Value which may be invalid. Internally uses mutable
   * collections when its desirable to do so, for performance and other reasons
@@ -282,16 +283,15 @@ final case class JArray(value: js.Array[JValue] = js.Array()) extends JValue {
   }
 
   override def toJsAny: js.Any = {
-    val jsArray = js.Array[js.Any]()
     val length = value.length
-    if (length != 0) {
-      var index = 0
-      while (index < length) {
-        jsArray.push(value(index).toJsAny)
-        index += 1
+    if (length == 0) {
+      js.Array[js.Any]()
+    } else {
+      val jsArray = value.asInstanceOf[js.Array[js.Any | JValue]]
+      jsArray.map { v =>
+        v.asInstanceOf[JValue].toJsAny
       }
     }
-    jsArray
   }
 
   override def equals(obj: scala.Any): Boolean = {

--- a/js/src/main/scala/scalajson/ast/unsafe/JValue.scala
+++ b/js/src/main/scala/scalajson/ast/unsafe/JValue.scala
@@ -3,6 +3,7 @@ package unsafe
 
 import scalajson.ast
 import scala.scalajs.js
+import scala.scalajs.js.|
 
 /** Represents a JSON Value which may be invalid. Internally uses mutable
   * collections when its desirable to do so, for performance and other reasons
@@ -281,16 +282,15 @@ final case class JArray(value: js.Array[JValue] = js.Array()) extends JValue {
   }
 
   override def toJsAny: js.Any = {
-    val jsArray = js.Array[js.Any]()
     val length = value.length
-    if (length != 0) {
-      var index = 0
-      while (index < length) {
-        jsArray.push(value(index).toJsAny)
-        index += 1
+    if (length == 0) {
+      js.Array[js.Any]()
+    } else {
+      val jsArray = value.asInstanceOf[js.Array[js.Any | JValue]]
+      jsArray.map { v =>
+        v.asInstanceOf[JValue].toJsAny
       }
     }
-    jsArray
   }
 
   override def equals(obj: scala.Any): Boolean = {


### PR DESCRIPTION
This version of `.toJsAny` should be faster since we just mutate an array in place rather than creating a new array and putting elements onto it. Still need to verify this with some benchmarking.

Note that `.asInstanceOf` casts in Scala.js are always free