### PR TITLE
Initial support for scala-native

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -89,7 +89,7 @@ lazy val commonSettings = Seq(
     "https://opensource.org/licenses/BSD-3-Clause"))
 )
 
-lazy val scalaJson = crossProject(JSPlatform, JVMPlatform)
+lazy val scalaJson = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .in(file("."))
   .settings(
     commonSettings,
@@ -144,6 +144,9 @@ lazy val scalaJson = crossProject(JSPlatform, JVMPlatform)
     testFrameworks += TestFrameworks.ScalaTest,
     scalacOptions in Test ++= Seq("-Yrangepos")
   )
+  .nativeSettings(
+    crossScalaVersions := Seq(currentScalaVersion)
+  )
 
 lazy val benchmark = crossProject(JSPlatform, JVMPlatform)
   .in(file("benchmark"))
@@ -160,3 +163,4 @@ lazy val scalaJsonJSTest = benchmark.js
 
 lazy val scalaJsonJVM = scalaJson.jvm
 lazy val scalaJsonJS = scalaJson.js
+lazy val scalaJsonNative = scalaJson.native

--- a/native/src/main/scala/scalajson/ast/JValue.scala
+++ b/native/src/main/scala/scalajson/ast/JValue.scala
@@ -1,0 +1,206 @@
+package scalajson.ast
+
+/** Represents a valid JSON Value
+  *
+  * @author Matthew de Detrich
+  * @see https://www.ietf.org/rfc/rfc4627.txt
+  */
+sealed abstract class JValue extends Product with Serializable {
+
+  /**
+    * Converts a [[JValue]] to a [[unsafe.JValue]]. Note that
+    * when converting [[JObject]], this can produce [[unsafe.JObject]] of
+    * unknown ordering, since ordering on a [[scala.collection.Map]] isn't defined. Duplicate keys will also
+    * be removed in an undefined manner.
+    *
+    * @see https://www.ietf.org/rfc/rfc4627.txt
+    * @return
+    */
+  def toUnsafe: unsafe.JValue
+}
+
+/** Represents a JSON null value
+  *
+  * @author Matthew de Detrich
+  */
+final case object JNull extends JValue {
+  override def toUnsafe: unsafe.JValue = unsafe.JNull
+}
+
+/** Represents a JSON string value
+  *
+  * @author Matthew de Detrich
+  */
+final case class JString(value: String) extends JValue {
+  override def toUnsafe: unsafe.JValue = unsafe.JString(value)
+}
+
+/**
+  * If you are passing in a NaN or Infinity as a Double, JNumber will
+  * return a JNull
+  */
+object JNumber {
+  def apply(value: Int): JNumber = new JNumber(value.toString)
+
+  def apply(value: Long): JNumber = new JNumber(value.toString)
+
+  def apply(value: BigInt): JNumber = new JNumber(value.toString)
+
+  /**
+    * @param value
+    * @return Will return a [[JNull]] if value is a Nan or Infinity
+    */
+  def apply(value: Float): JValue = value match {
+    case n if java.lang.Float.isNaN(n) => JNull
+    case n if n.isInfinity             => JNull
+    case _                             => new JNumber(value.toString)
+  }
+
+  def apply(value: BigDecimal): JNumber = new JNumber(value.toString())
+
+  /**
+    * @param value
+    * @return Will return a [[JNull]] if value is a Nan or Infinity
+    */
+  def apply(value: Double): JValue = value match {
+    case n if n.isNaN      => JNull
+    case n if n.isInfinity => JNull
+    case _                 => new JNumber(value.toString)
+  }
+
+  def apply(value: Integer): JNumber = new JNumber(value.toString)
+
+  def apply(value: Array[Char]): Option[JNumber] =
+    fromString(new String(value))
+
+  def apply(value: String): Option[JNumber] = fromString(value)
+
+  def fromString(value: String): Option[JNumber] =
+    value match {
+      case jNumberRegex(_*) => Some(new JNumber(value))
+      case _                => None
+    }
+}
+
+/** Represents a JSON number value. If you are passing in a
+  * NaN or Infinity as a [[scala.Double]] or [[scala.Float]], [[JNumber]] will
+  * return a [[JNull]].
+  *
+  * @author Matthew de Detrich
+  */
+final case class JNumber private[ast] (value: String) extends JValue {
+  override def toUnsafe: unsafe.JValue = unsafe.JNumber(value)
+
+  override def equals(obj: Any): Boolean =
+    obj match {
+      case jNumber: JNumber =>
+        numericStringEquals(value, jNumber.value)
+      case _ => false
+    }
+
+  override def hashCode: Int =
+    numericStringHashcode(value)
+
+  def copy(value: String): JNumber =
+    value match {
+      case jNumberRegex(_*) => new JNumber(value)
+      case _                => throw new NumberFormatException(value)
+    }
+
+  def toInt: Option[Int] = scalajson.ast.toInt(value)
+
+  def toBigInt: Option[BigInt] = scalajson.ast.toBigInt(value)
+
+  def toLong: Option[Long] = scalajson.ast.toLong(value)
+
+  def toDouble: Double = scalajson.ast.toDouble(value)
+
+  def toFloat: Float = scalajson.ast.toFloat(value)
+
+  def toBigDecimal: Option[BigDecimal] = scalajson.ast.toBigDecimal(value)
+}
+
+/** Represents a JSON Boolean value, which can either be a
+  * [[JTrue]] or a [[JFalse]]
+  *
+  * @author Matthew de Detrich
+  */
+// Implements named extractors so we can avoid boxing
+sealed abstract class JBoolean extends JValue {
+  def isEmpty: Boolean = false
+  def get: Boolean
+}
+
+object JBoolean {
+  def apply(x: Boolean): JBoolean = if (x) JTrue else JFalse
+
+  def unapply(x: JBoolean): Some[Boolean] = Some(x.get)
+}
+
+/** Represents a JSON Boolean true value
+  *
+  * @author Matthew de Detrich
+  */
+final case object JTrue extends JBoolean {
+  override def get = true
+
+  override def toUnsafe: unsafe.JValue = unsafe.JTrue
+}
+
+/** Represents a JSON Boolean false value
+  *
+  * @author Matthew de Detrich
+  */
+final case object JFalse extends JBoolean {
+  override def get = false
+
+  override def toUnsafe: unsafe.JValue = unsafe.JFalse
+}
+
+/** Represents a JSON Object value. Keys must be unique
+  * and are unordered
+  *
+  * @author Matthew de Detrich
+  */
+final case class JObject(value: Map[String, JValue] = Map.empty)
+  extends JValue {
+  override def toUnsafe: unsafe.JValue = {
+    if (value.isEmpty) {
+      unsafe.JArray(Array.ofDim[unsafe.JValue](0))
+    } else {
+      val array = Array.ofDim[unsafe.JField](value.size)
+      var index = 0
+      value.iterator.foreach { x =>
+        array(index) = unsafe.JField(x._1, x._2.toUnsafe)
+        index += 1
+      }
+      unsafe.JObject(array)
+    }
+  }
+}
+
+object JArray {
+  def apply(value: JValue, values: JValue*): JArray =
+    JArray(value +: values.toVector)
+}
+
+/** Represents a JSON Array value
+  *
+  * @author Matthew de Detrich
+  */
+final case class JArray(value: Vector[JValue] = Vector.empty) extends JValue {
+  override def toUnsafe: unsafe.JValue = {
+    val length = value.length
+    if (length == 0) {
+      unsafe.JArray(Array.ofDim[unsafe.JValue](0))
+    } else {
+      val array = Array.ofDim[unsafe.JValue](length)
+      var index = 0
+      value.foreach { x =>
+        array(index) = x.toUnsafe
+        index += 1
+      }
+      unsafe.JArray(array)
+    }
+  }
+}

--- a/native/src/main/scala/scalajson/ast/unsafe/JValue.scala
+++ b/native/src/main/scala/scalajson/ast/unsafe/JValue.scala
@@ -1,0 +1,232 @@
+package scalajson.ast
+package unsafe
+
+import scalajson.ast
+import scalajson.ast._
+
+/** Represents a JSON Value which may be invalid. Internally uses mutable
+  * collections when its desirable to do so, for performance and other reasons
+  * (such as ordering and duplicate keys)
+  *
+  * @author Matthew de Detrich
+  * @see https://www.ietf.org/rfc/rfc4627.txt
+  */
+sealed abstract class JValue extends Serializable with Product {
+
+  /**
+    * Converts a [[unsafe.JValue]] to a [[ast.JValue]]. Note that
+    * when converting [[unsafe.JNumber]], this can throw runtime error if the underlying
+    * string representation is not a correct number. Also when converting a [[unsafe.JObject]]
+    * to a [[ast.JObject]], its possible to lose data if you have duplicate keys.
+    *
+    * @see https://www.ietf.org/rfc/rfc4627.txt
+    * @return
+    */
+  def toStandard: ast.JValue
+}
+
+/** Represents a JSON null value
+  *
+  * @author Matthew de Detrich
+  */
+final case object JNull extends JValue {
+  override def toStandard: ast.JValue = ast.JNull
+}
+
+/** Represents a JSON string value
+  *
+  * @author Matthew de Detrich
+  */
+final case class JString(value: String) extends JValue {
+  override def toStandard: ast.JValue = ast.JString(value)
+}
+
+object JNumber {
+  def apply(value: Int): JNumber = JNumber(value.toInt.toString)
+
+  def apply(value: Long): JNumber = JNumber(value.toString)
+
+  def apply(value: BigInt): JNumber = JNumber(value.toString)
+
+  def apply(value: BigDecimal): JNumber = JNumber(value.toString)
+
+  def apply(value: Float): JNumber = JNumber(value.toString)
+
+  def apply(value: Double): JNumber = JNumber(value.toString)
+
+  def apply(value: Integer): JNumber = JNumber(value.toString)
+
+  def apply(value: Array[Char]): JNumber = JNumber(new String(value))
+}
+
+/** Represents a JSON number value.
+  *
+  * If you are passing in a NaN or Infinity as a [[scala.Double]], [[unsafe.JNumber]]
+  * will contain "NaN" or "Infinity" as a String which means it will cause
+  * issues for users when they use the value at runtime. It may be
+  * preferable to check values yourself when constructing [[unsafe.JValue]]
+  * to prevent this. This isn't checked by default for performance reasons.
+  *
+  * @author Matthew de Detrich
+  */
+// JNumber is internally represented as a string, to improve performance
+final case class JNumber(value: String) extends JValue {
+  override def toStandard: ast.JValue =
+    value match {
+      case jNumberRegex(_*) => new ast.JNumber(value)
+      case _                => throw new NumberFormatException(value)
+    }
+
+  def toInt: Option[Int] = scalajson.ast.toInt(value)
+
+  def toBigInt: Option[BigInt] = scalajson.ast.toBigInt(value)
+
+  def toLong: Option[Long] = scalajson.ast.toLong(value)
+
+  def toDouble: Double = scalajson.ast.toDouble(value)
+
+  def toFloat: Float = scalajson.ast.toFloat(value)
+
+  def toBigDecimal: Option[BigDecimal] = scalajson.ast.toBigDecimal(value)
+}
+
+/** Represents a JSON Boolean value, which can either be a
+  * [[JTrue]] or a [[JFalse]]
+  *
+  * @author Matthew de Detrich
+  */
+// Implements named extractors so we can avoid boxing
+sealed abstract class JBoolean extends JValue {
+  def isEmpty: Boolean = false
+  def get: Boolean
+}
+
+object JBoolean {
+  def apply(x: Boolean): JBoolean = if (x) JTrue else JFalse
+
+  def unapply(x: JBoolean): Some[Boolean] = Some(x.get)
+}
+
+/** Represents a JSON Boolean true value
+  *
+  * @author Matthew de Detrich
+  */
+final case object JTrue extends JBoolean {
+  override def get = true
+
+  override def toStandard: ast.JValue = ast.JTrue
+}
+
+/** Represents a JSON Boolean false value
+  *
+  * @author Matthew de Detrich
+  */
+final case object JFalse extends JBoolean {
+  override def get = false
+
+  override def toStandard: ast.JValue = ast.JFalse
+}
+
+final case class JField(field: String, value: JValue)
+
+object JObject {
+  def apply(value: JField, values: JField*): JObject =
+    JObject(Array(value) ++ values)
+}
+
+/** Represents a JSON Object value. Duplicate keys
+  * are allowed and ordering is respected
+  * @author Matthew de Detrich
+  */
+// JObject is internally represented as a mutable Array, to improve sequential performance
+final case class JObject(value: Array[JField] = Array.empty) extends JValue {
+  override def toStandard: ast.JValue = {
+    val length = value.length
+    if (length == 0) {
+      ast.JObject(Map[String, ast.JValue]())
+    } else {
+      var index = 0
+      val b = Map.newBuilder[String, ast.JValue]
+      while (index < length) {
+        val v = value(index)
+        b += ((v.field, v.value.toStandard))
+        index += 1
+      }
+      ast.JObject(b.result())
+    }
+  }
+
+  override def equals(obj: scala.Any): Boolean = {
+    obj match {
+      case jObject: JObject =>
+        val length = value.length
+        if (length != jObject.value.length)
+          return false
+        var index = 0
+        while (index < length) {
+          if (value(index) != jObject.value(index))
+            return false
+          index += 1
+        }
+        true
+      case _ => false
+    }
+  }
+
+  override def hashCode: Int =
+    java.util.Arrays.deepHashCode(value.asInstanceOf[Array[AnyRef]])
+
+  override def toString =
+    "JObject(" + java.util.Arrays
+      .toString(value.asInstanceOf[Array[AnyRef]]) + ")"
+}
+
+object JArray {
+  def apply(value: JValue, values: JValue*): JArray =
+    JArray(Array(value) ++ values.toArray[JValue])
+}
+
+/** Represents a JSON Array value
+  * @author Matthew de Detrich
+  */
+// JArray is internally represented as a mutable Array, to improve sequential performance
+final case class JArray(value: Array[JValue] = Array.empty) extends JValue {
+  override def toStandard: ast.JValue = {
+    val length = value.length
+    if (length == 0) {
+      ast.JArray(Vector[ast.JValue]())
+    } else {
+      var index = 0
+      val b = Vector.newBuilder[ast.JValue]
+      while (index < length) {
+        b += value(index).toStandard
+        index += 1
+      }
+      ast.JArray(b.result())
+    }
+  }
+
+  override def equals(obj: scala.Any): Boolean = {
+    obj match {
+      case jArray: JArray =>
+        val length = value.length
+        if (length != jArray.value.length)
+          return false
+        var index = 0
+        while (index < length) {
+          if (value(index) != jArray.value(index))
+            return false
+          index += 1
+        }
+        true
+      case _ => false
+    }
+  }
+
+  override def hashCode: Int =
+    java.util.Arrays.deepHashCode(value.asInstanceOf[Array[AnyRef]])
+
+  override def toString =
+    "JArray(" + java.util.Arrays
+      .toString(value.asInstanceOf[Array[AnyRef]]) + ")"
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,10 @@
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.22")
 
-addSbtPlugin("org.scala-native" % "sbt-crossproject" % "0.2.2")
+addSbtPlugin("org.portable-scala" % "sbt-crossproject" % "0.3.1")
 
-addSbtPlugin("org.scala-native" % "sbt-scalajs-crossproject" % "0.2.2")
+addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.3.1")
+
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.3.6")
 
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.4.0")
 


### PR DESCRIPTION
This PR adds initial support for scala-native, current issues

1. ScalaTest is not yet available on scala-native, see https://github.com/scalatest/scalatest/issues/1112
2. There is no benchmarking yet for scala-native (same problem as Scala.js)
3. The sources for scala-native are *exactly* the same as JVM. Ideally this should be a shared source directory, but there are arguments against sharing across JVM and native. Furthermore it may be possible to do some optimisations that are only possible on scala-native (i.e. using stuff like `CStruct`?). Also just like with `Scala.js`, we may expose interopt 