### PR TITLE
Allow you to supply a custom collection on .toStandard

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -133,7 +133,7 @@ lazy val scalaJson = crossProject(JSPlatform, JVMPlatform, NativePlatform)
       "org.scalatest" %% "scalatest" % scalaTestVersion % Test,
       "org.scalacheck" %% "scalacheck" % scalaCheckVersion % Test
     ),
-    scalacOptions in Test ++= Seq("-Yrangepos"),
+    // scalacOptions in Test ++= Seq("-Yrangepos"), TODO Remove when https://github.com/scala/bug/issues/10706 is merged
     mimaPreviousArtifacts := Set(
       "org.scala-lang.platform" %% "scalajson" % "1.0.0-M3")
   )
@@ -143,8 +143,8 @@ lazy val scalaJson = crossProject(JSPlatform, JVMPlatform, NativePlatform)
       "org.scalatest" %%% "scalatest" % scalaTestVersion % Test,
       "org.scalacheck" %%% "scalacheck" % scalaCheckVersion % Test
     ),
-    testFrameworks += TestFrameworks.ScalaTest,
-    scalacOptions in Test ++= Seq("-Yrangepos")
+    testFrameworks += TestFrameworks.ScalaTest
+    // scalacOptions in Test ++= Seq("-Yrangepos") TODO Remove when https://github.com/scala/bug/issues/10706 is merged
   )
   .nativeSettings(
     crossScalaVersions := Seq(currentScalaVersion)

--- a/js/src/main/scala-2.10/scalajson.ast/unsafe/JValue.scala
+++ b/js/src/main/scala-2.10/scalajson.ast/unsafe/JValue.scala
@@ -24,6 +24,7 @@ sealed abstract class JValue extends Serializable with Product {
     * string representation is not a correct number. Also when converting a [[ast.JObject]]
     * to a [[ast.JObject]], its possible to lose data if you have duplicate keys.
     *
+    * @tparam C An immutable Map abstraction, by default its [[scala.collection.immutable.Map]]
     * @see https://www.ietf.org/rfc/rfc4627.txt
     * @return
     */

--- a/js/src/main/scala-2.10/scalajson.ast/unsafe/JValue.scala
+++ b/js/src/main/scala-2.10/scalajson.ast/unsafe/JValue.scala
@@ -1,6 +1,8 @@
 package scalajson.ast
 package unsafe
 
+import scala.collection.generic.CanBuildFrom
+import scala.language.higherKinds
 import scalajson.ast
 import scalajson.ast._
 import scala.scalajs.js
@@ -15,6 +17,7 @@ import scala.scalajs.js.annotation.JSExport
   */
 sealed abstract class JValue extends Serializable with Product {
 
+  private[unsafe] type CBF[C[A, B] <: Map[A, B]] = CanBuildFrom[Nothing, (String, ast.JValue), C[String, ast.JValue]]
   /**
     * Converts a [[unsafe.JValue]] to a [[ast.JValue]]. Note that
     * when converting [[unsafe.JNumber]], this can throw runtime error if the underlying
@@ -24,7 +27,7 @@ sealed abstract class JValue extends Serializable with Product {
     * @see https://www.ietf.org/rfc/rfc4627.txt
     * @return
     */
-  def toStandard: ast.JValue
+  def toStandard[C[A, B] <: Map[A, B]](implicit cbf: CBF[C]): ast.JValue
 
   /**
     * Converts a [[unsafe.JValue]] to a Javascript object/value that can be used within
@@ -40,7 +43,7 @@ sealed abstract class JValue extends Serializable with Product {
   * @author Matthew de Detrich
   */
 final case object JNull extends JValue {
-  override def toStandard: ast.JValue = ast.JNull
+  override def toStandard[C[A, B] <: Map[A, B]](implicit cbf: CBF[C]): ast.JValue = ast.JNull
 
   override def toJsAny: js.Any = null
 }
@@ -50,7 +53,7 @@ final case object JNull extends JValue {
   * @author Matthew de Detrich
   */
 final case class JString(value: String) extends JValue {
-  override def toStandard: ast.JValue = ast.JString(value)
+  override def toStandard[C[A, B] <: Map[A, B]](implicit cbf: CBF[C]): ast.JValue = ast.JString(value)
 
   override def toJsAny: js.Any = value
 }
@@ -85,7 +88,7 @@ object JNumber {
   */
 // JNumber is internally represented as a string, to improve performance
 final case class JNumber(value: String) extends JValue {
-  override def toStandard: ast.JValue =
+  override def toStandard[C[A, B] <: Map[A, B]](implicit cbf: CBF[C]): ast.JValue =
     value match {
       case jNumberRegex(_*) => new ast.JNumber(value)
       case _                => throw new NumberFormatException(value)
@@ -135,7 +138,7 @@ object JBoolean {
 final case object JTrue extends JBoolean {
   override def get = true
 
-  override def toStandard: ast.JValue = ast.JTrue
+  override def toStandard[C[A, B] <: Map[A, B]](implicit cbf: CBF[C]): ast.JValue = ast.JTrue
 }
 
 /** Represents a JSON Boolean false value
@@ -145,7 +148,7 @@ final case object JTrue extends JBoolean {
 final case object JFalse extends JBoolean {
   override def get = false
 
-  override def toStandard: ast.JValue = ast.JFalse
+  override def toStandard[C[A, B] <: Map[A, B]](implicit cbf: CBF[C]): ast.JValue = ast.JFalse
 }
 
 final case class JField(field: String, value: JValue)
@@ -174,15 +177,14 @@ final case class JObject(value: js.Array[JField] = js.Array()) extends JValue {
     })
   }
 
-  override def toStandard: ast.JValue = {
+  override def toStandard[C[A, B] <: Map[A, B]](implicit cbf: CBF[C]): ast.JValue = {
     // Javascript array.length across all major browsers has near constant cost, so we
     // use this to build the array http://jsperf.com/length-comparisons
     val length = value.length
-
+    val b = cbf()
     if (length == 0) {
-      ast.JObject(Map.newBuilder[String, ast.JValue].result())
+      ast.JObject(b.result())
     } else {
-      val b = Map.newBuilder[String, ast.JValue]
       var index = 0
       while (index < length) {
         val v = value(index)
@@ -264,7 +266,7 @@ object JArray {
   */
 // JArray is internally represented as a mutable js.Array, to improve sequential performance
 final case class JArray(value: js.Array[JValue] = js.Array()) extends JValue {
-  override def toStandard: ast.JValue = {
+  override def toStandard[C[A, B] <: Map[A, B]](implicit cbf: CBF[C]): ast.JValue = {
     // Javascript array.length across all major browsers has near constant cost, so we
     // use this to build the array http://jsperf.com/length-comparisons
     val length = value.length

--- a/js/src/main/scala/scalajson/ast/unsafe/JValue.scala
+++ b/js/src/main/scala/scalajson/ast/unsafe/JValue.scala
@@ -24,6 +24,7 @@ sealed abstract class JValue extends Serializable with Product {
     * string representation is not a correct number. Also when converting a [[ast.JObject]]
     * to a [[ast.JObject]], its possible to lose data if you have duplicate keys.
     *
+    * @tparam C An immutable Map abstraction, by default its [[scala.collection.immutable.Map]]
     * @see https://www.ietf.org/rfc/rfc4627.txt
     * @return
     */

--- a/jvm/src/main/scala-2.10/scalajson.ast/unsafe/JValue.scala
+++ b/jvm/src/main/scala-2.10/scalajson.ast/unsafe/JValue.scala
@@ -1,6 +1,8 @@
 package scalajson.ast
 package unsafe
 
+import scala.collection.generic.CanBuildFrom
+import scala.language.higherKinds
 import scalajson.ast
 import scalajson.ast._
 
@@ -13,6 +15,7 @@ import scalajson.ast._
   */
 sealed abstract class JValue extends Serializable with Product {
 
+  private[unsafe] type CBF[C[A, B] <: Map[A, B]] = CanBuildFrom[Nothing, (String, ast.JValue), C[String, ast.JValue]]
   /**
     * Converts a [[unsafe.JValue]] to a [[ast.JValue]]. Note that
     * when converting [[unsafe.JNumber]], this can throw runtime error if the underlying
@@ -22,7 +25,7 @@ sealed abstract class JValue extends Serializable with Product {
     * @see https://www.ietf.org/rfc/rfc4627.txt
     * @return
     */
-  def toStandard: ast.JValue
+  def toStandard[C[A, B] <: Map[A, B]](implicit cbf: CBF[C]): ast.JValue
 }
 
 /** Represents a JSON null value
@@ -30,7 +33,7 @@ sealed abstract class JValue extends Serializable with Product {
   * @author Matthew de Detrich
   */
 final case object JNull extends JValue {
-  override def toStandard: ast.JValue = ast.JNull
+  override def toStandard[C[A, B] <: Map[A, B]](implicit cbf: CBF[C]): ast.JValue = ast.JNull
 }
 
 /** Represents a JSON string value
@@ -38,7 +41,7 @@ final case object JNull extends JValue {
   * @author Matthew de Detrich
   */
 final case class JString(value: String) extends JValue {
-  override def toStandard: ast.JValue = ast.JString(value)
+  override def toStandard[C[A, B] <: Map[A, B]](implicit cbf: CBF[C]): ast.JValue = ast.JString(value)
 }
 
 object JNumber {
@@ -71,7 +74,7 @@ object JNumber {
   */
 // JNumber is internally represented as a string, to improve performance
 final case class JNumber(value: String) extends JValue {
-  override def toStandard: ast.JValue =
+  override def toStandard[C[A, B] <: Map[A, B]](implicit cbf: CBF[C]): ast.JValue =
     value match {
       case jNumberRegex(_ *) => new ast.JNumber(value)
       case _ => throw new NumberFormatException(value)
@@ -113,7 +116,7 @@ object JBoolean {
 final case object JTrue extends JBoolean {
   override def get = true
 
-  override def toStandard: ast.JValue = ast.JTrue
+  override def toStandard[C[A, B] <: Map[A, B]](implicit cbf: CBF[C]): ast.JValue = ast.JTrue
 }
 
 /** Represents a JSON Boolean false value
@@ -123,7 +126,7 @@ final case object JTrue extends JBoolean {
 final case object JFalse extends JBoolean {
   override def get = false
 
-  override def toStandard: ast.JValue = ast.JFalse
+  override def toStandard[C[A, B] <: Map[A, B]](implicit cbf: CBF[C]): ast.JValue = ast.JFalse
 }
 
 final case class JField(field: String, value: JValue)
@@ -139,13 +142,13 @@ object JObject {
   */
 // JObject is internally represented as a mutable Array, to improve sequential performance
 final case class JObject(value: Array[JField] = Array.empty) extends JValue {
-  override def toStandard: ast.JValue = {
+  override def toStandard[C[A, B] <: Map[A, B]](implicit cbf: CBF[C]): ast.JValue = {
     val length = value.length
+    val b = cbf()
     if (length == 0) {
-      ast.JObject(Map[String, ast.JValue]())
+      ast.JObject(b.result())
     } else {
       var index = 0
-      val b = Map.newBuilder[String, ast.JValue]
       while (index < length) {
         val v = value(index)
         b += ((v.field, v.value.toStandard))
@@ -189,7 +192,7 @@ object JArray {
   */
 // JArray is internally represented as a mutable Array, to improve sequential performance
 final case class JArray(value: Array[JValue] = Array.empty) extends JValue {
-  override def toStandard: ast.JValue = {
+  override def toStandard[C[A, B] <: Map[A, B]](implicit cbf: CBF[C]): ast.JValue = {
     val length = value.length
     if (length == 0) {
       ast.JArray(Vector[ast.JValue]())

--- a/jvm/src/main/scala-2.10/scalajson.ast/unsafe/JValue.scala
+++ b/jvm/src/main/scala-2.10/scalajson.ast/unsafe/JValue.scala
@@ -22,6 +22,7 @@ sealed abstract class JValue extends Serializable with Product {
     * string representation is not a correct number. Also when converting a [[unsafe.JObject]]
     * to a [[ast.JObject]], its possible to lose data if you have duplicate keys.
     *
+    * @tparam C An immutable Map abstraction, by default its [[scala.collection.immutable.Map]]
     * @see https://www.ietf.org/rfc/rfc4627.txt
     * @return
     */

--- a/shared/src/test/scala/specs/Counted.scala
+++ b/shared/src/test/scala/specs/Counted.scala
@@ -13,7 +13,7 @@ trait Counted extends Any {
   def validate(): Unit = {
     count match {
       case neg if neg < 0 => throwOnNegative()
-      case pos =>
+      case pos            =>
     }
   }
 

--- a/shared/src/test/scala/specs/Generators.scala
+++ b/shared/src/test/scala/specs/Generators.scala
@@ -44,10 +44,11 @@ object Generators {
       maxWidth: Width = defaultMaxWidth): Arbitrary[scalajson.ast.JArray] =
     Arbitrary(genJsArray)
 
-  implicit def arbJsString(implicit arbString: Arbitrary[String])
-    : Arbitrary[scalajson.ast.JString] = Arbitrary {
-    arbString.arbitrary map scalajson.ast.JString
-  }
+  implicit def arbJsString(
+      implicit arbString: Arbitrary[String]): Arbitrary[scalajson.ast.JString] =
+    Arbitrary {
+      arbString.arbitrary map scalajson.ast.JString
+    }
 
   implicit def arbJsNumber: Arbitrary[scalajson.ast.JNumber] = Arbitrary {
     genSafeBigDecimal map (x =>
@@ -129,9 +130,8 @@ object Generators {
     * @param maxDepth see [[defaultMaxDepth]] (cannot be less than 1)
     * @param maxWidth see [[defaultMaxWidth]] (cannot be less than 1)
     */
-  def genJsArray(
-      implicit maxDepth: Depth = defaultMaxDepth,
-      maxWidth: Width = defaultMaxWidth): Gen[scalajson.ast.JArray] =
+  def genJsArray(implicit maxDepth: Depth = defaultMaxDepth,
+                 maxWidth: Width = defaultMaxWidth): Gen[scalajson.ast.JArray] =
     Gen.containerOfN[Vector, scalajson.ast.JValue](
       maxWidth,
       genJsValue(maxDepth - 1, maxWidth)) map { scalajson.ast.JArray.apply }
@@ -184,8 +184,8 @@ object Generators {
 
   implicit val shrinkJsValue: Shrink[scalajson.ast.JValue] = Shrink {
     case array: scalajson.ast.JArray => shrink(array)
-    case obj: scalajson.ast.JObject => shrink(obj)
-    case scalajson.ast.JString(str) => shrink(str) map scalajson.ast.JString
+    case obj: scalajson.ast.JObject  => shrink(obj)
+    case scalajson.ast.JString(str)  => shrink(str) map scalajson.ast.JString
     case scalajson.ast.JNumber(num) =>
       shrink(num) map (x => scalajson.ast.JNumber.fromString(x).get)
     case scalajson.ast.JNull | scalajson.ast.JBoolean(_) =>

--- a/shared/src/test/scala/specs/JArray.scala
+++ b/shared/src/test/scala/specs/JArray.scala
@@ -15,7 +15,7 @@ class JArray extends Spec {
         Utils.unsafeJValueEquals(
           jArray.toUnsafe,
           scalajson.ast.unsafe.JArray(values)
-        ) should be (true)
+        ) should be(true)
       }
     }
 

--- a/shared/src/test/scala/specs/JBoolean.scala
+++ b/shared/src/test/scala/specs/JBoolean.scala
@@ -12,7 +12,7 @@ class JBoolean extends Spec {
 
     "pattern match with JTrue" in {
       forAll { b: Boolean =>
-        whenever (b == true) {
+        whenever(b == true) {
           val result = JBoolean(b) match {
             case f @ JTrue => f
           }
@@ -31,7 +31,7 @@ class JBoolean extends Spec {
 
     "pattern match with JFalse" in {
       forAll { b: Boolean =>
-        whenever (b == false) {
+        whenever(b == false) {
           val result = JBoolean(b) match {
             case f @ JFalse => f
           }
@@ -69,7 +69,7 @@ class JBoolean extends Spec {
 
     "pattern match with JBoolean as false" in {
       forAll { b: Boolean =>
-        whenever {b == false} {
+        whenever { b == false } {
           val result = JBoolean(b) match {
             case f @ JBoolean(false) => f
           }
@@ -94,7 +94,7 @@ class JBoolean extends Spec {
     }
 
     "equals" in {
-      forAll {b: Boolean =>
+      forAll { b: Boolean =>
         scalajson.ast.JBoolean(b) should be(scalajson.ast.JBoolean(b))
       }
     }
@@ -104,7 +104,7 @@ class JBoolean extends Spec {
   "The JTrue value" should {
     "read a Boolean as true" in {
       forAll { b: Boolean =>
-        whenever (b == true) {
+        whenever(b == true) {
           JTrue.get should be(b)
         }
       }
@@ -114,7 +114,7 @@ class JBoolean extends Spec {
   "The JFalse value" should {
     "read a Boolean as false" in {
       forAll { b: Boolean =>
-        whenever (b == false) {
+        whenever(b == false) {
           JFalse.get should be(b)
         }
       }

--- a/shared/src/test/scala/specs/JObject.scala
+++ b/shared/src/test/scala/specs/JObject.scala
@@ -5,18 +5,18 @@ import Generators._
 class JObject extends Spec {
   "The JObject value" should {
     "convert toUnsafe" in {
-      forAll{ jObject: scalajson.ast.JObject =>
+      forAll { jObject: scalajson.ast.JObject =>
         val values = jObject.value.map {
           case (k, v) =>
             scalajson.ast.unsafe.JField(k, v.toUnsafe)
         }
         Utils.unsafeJValueEquals(jObject.toUnsafe,
-          scalajson.ast.unsafe.JObject(values.toArray))
+                                 scalajson.ast.unsafe.JObject(values.toArray))
       }
     }
 
     "equals" in {
-      forAll {jObject: scalajson.ast.JObject =>
+      forAll { jObject: scalajson.ast.JObject =>
         scalajson.ast.JObject(jObject.value) should be(
           scalajson.ast.JObject(jObject.value))
       }

--- a/shared/src/test/scala/specs/JValue.scala
+++ b/shared/src/test/scala/specs/JValue.scala
@@ -12,7 +12,8 @@ class JValue extends Spec {
             scalajson.ast.JNumber.fromString(jNumber.value).get
           case jString: scalajson.ast.JString =>
             scalajson.ast.JString(jString.value)
-          case jArray: scalajson.ast.JArray => scalajson.ast.JArray(jArray.value)
+          case jArray: scalajson.ast.JArray =>
+            scalajson.ast.JArray(jArray.value)
           case jObject: scalajson.ast.JObject =>
             scalajson.ast.JObject(jObject.value)
           case jBoolean: scalajson.ast.JBoolean =>

--- a/shared/src/test/scala/specs/Utils.scala
+++ b/shared/src/test/scala/specs/Utils.scala
@@ -12,13 +12,11 @@ object Utils {
   def unsafeJValueEquals(left: scalajson.ast.unsafe.JValue,
                          right: scalajson.ast.unsafe.JValue): Boolean = {
     (left, right) match {
-      case (l: scalajson.ast.unsafe.JString,
-            r: scalajson.ast.unsafe.JString) =>
+      case (l: scalajson.ast.unsafe.JString, r: scalajson.ast.unsafe.JString) =>
         l == r
       case (scalajson.ast.unsafe.JNull, scalajson.ast.unsafe.JNull) =>
         true
-      case (l: scalajson.ast.unsafe.JNumber,
-            r: scalajson.ast.unsafe.JNumber) =>
+      case (l: scalajson.ast.unsafe.JNumber, r: scalajson.ast.unsafe.JNumber) =>
         l == r
       case (l: scalajson.ast.unsafe.JArray, r: scalajson.ast.unsafe.JArray) =>
         val rValue = r.value
@@ -29,8 +27,7 @@ object Utils {
       case (l: scalajson.ast.unsafe.JBoolean,
             r: scalajson.ast.unsafe.JBoolean) =>
         l == r
-      case (l: scalajson.ast.unsafe.JObject,
-            r: scalajson.ast.unsafe.JObject) =>
+      case (l: scalajson.ast.unsafe.JObject, r: scalajson.ast.unsafe.JObject) =>
         val rAsMap = r.value.map { field =>
           (field.field, field.value)
         }.toMap
@@ -41,7 +38,7 @@ object Utils {
           case (k, value) =>
             lAsMap.get(k) match {
               case Some(lValue) => unsafeJValueEquals(lValue, value)
-              case _ => false
+              case _            => false
             }
         }
 

--- a/shared/src/test/scala/specs/unsafe/Generators.scala
+++ b/shared/src/test/scala/specs/unsafe/Generators.scala
@@ -176,8 +176,7 @@ object Generators {
 
   implicit val shrinkJsObject: Shrink[scalajson.ast.unsafe.JObject] = Shrink {
     obj =>
-      val stream
-        : Stream[scalajson.ast.unsafe.JObject] = shrink(obj.value) map {
+      val stream: Stream[scalajson.ast.unsafe.JObject] = shrink(obj.value) map {
         fields =>
           scalajson.ast.unsafe.JObject(fields)
       }
@@ -186,7 +185,7 @@ object Generators {
 
   implicit val shrinkJsValue: Shrink[scalajson.ast.unsafe.JValue] = Shrink {
     case array: scalajson.ast.unsafe.JArray => shrink(array)
-    case obj: scalajson.ast.unsafe.JObject => shrink(obj)
+    case obj: scalajson.ast.unsafe.JObject  => shrink(obj)
     case scalajson.ast.unsafe.JString(str) =>
       shrink(str) map scalajson.ast.unsafe.JString
     case scalajson.ast.unsafe.JNumber(num) =>

--- a/shared/src/test/scala/specs/unsafe/JBoolean.scala
+++ b/shared/src/test/scala/specs/unsafe/JBoolean.scala
@@ -60,7 +60,6 @@ class JBoolean extends Spec {
       }
     }
 
-
     "pattern match with JBoolean as true and fail with scala.MatchError" in {
       assertThrows[MatchError] {
         JBoolean(true) match {

--- a/shared/src/test/scala/specs/unsafe/JNumber.scala
+++ b/shared/src/test/scala/specs/unsafe/JNumber.scala
@@ -85,8 +85,10 @@ class JNumber extends Spec {
             .toOption
             .isEmpty
         } {
-          scala.util.Try(BigDecimal(JNumber(s).value)).toOption.isEmpty should be(
-            true)
+          scala.util
+            .Try(BigDecimal(JNumber(s).value))
+            .toOption
+            .isEmpty should be(true)
         }
       }
     }

--- a/shared/src/test/scala/specs/unsafe/JObject.scala
+++ b/shared/src/test/scala/specs/unsafe/JObject.scala
@@ -1,8 +1,11 @@
 package specs.unsafe
 
 import specs.Spec
+
 import scalajson.ast.unsafe._
 import Generators._
+
+import scala.collection.immutable.ListMap
 
 class JObject extends Spec {
 
@@ -13,6 +16,20 @@ class JObject extends Spec {
           (x.field, x.value.toStandard)
         }.toMap
         jObject.toStandard == scalajson.ast.JObject(values)
+      }
+    }
+
+    "convert toStandard with ListMap" in {
+      forAll { jObject: scalajson.ast.unsafe.JObject =>
+        val values = ListMap(
+          jObject.value
+            .map { x =>
+              (x.field, x.value.toStandard)
+            }
+            .groupBy { case (k, _) => k }
+            .map(_._2.head)
+            .toList: _*)
+        jObject.toStandard[ListMap] == scalajson.ast.JObject(values)
       }
     }
 


### PR DESCRIPTION
As discussed on the last scala center meeting, there was a request to add the feature where if you call `.toStandard` on an unsafe JSON AST, you have the ability to specify the type of `Map` so you can control whether you will lose key ordering and/or you will lose effectively constant lookup time.

This implementation uses an implicit `canBuildFrom` on the `.toStandard` method to construct the standard AST. The default collection is an immutable `Map`, but you can also use a `ListMap` or a `LinkedMap` by simply providing the type, i.e. you can do `toStandard` or `toStandard[ListMap]` or `toStandard[LinkedMap]`. This means there are no breaking source changes, you can use `.toStandard` just like you did before (and it will use the `Map` implementation just as before) but you can specify a custom type if you want.

Theoretically there shouldn't be any performance issue but I will have to run benchmarks to closely analyse. There are also alternate ways you can solve this problem, i.e. you can choose to put the `CBF[C[A, B] <: Map[A, B]] ` directly inside the JSON AST sealed abstract class. This means that on construction the JSON AST will contain the refined type of whatever `Map` type you constructed it with, on the other hand you will have a downside of making the AST more complex (with this method, its only the `.toStandard` method which is changed, otherwise the AST remains completely the same).

It should also be discussed whether or not such a feature is worth the complexity it adds (either this current PR or other proposals).

Also ran `scalafmt` on test source so there is some noise in the PR.

@jvican @Ichoran